### PR TITLE
fixes undefined property error

### DIFF
--- a/wp-nav-submenu.php
+++ b/wp-nav-submenu.php
@@ -55,7 +55,7 @@ if (function_exists('add_filter')) {
                     unset($sorted_menu_items[$key]);
                 }
             }
-            if (!$args->show_parent_only) {
+            if (!empty($args->show_parent_only) && !$args->show_parent_only) {
                 if (count($sorted_menu_items) > 1) {
                     return $sorted_menu_items;
                 } else {


### PR DESCRIPTION
### Undefined Property Error 

-----

I tested this fix on MDC with no issues. 
Rob Voss helped debug error. 
--

Error being generated: 

`Notice: Undefined property: stdClass::$show_parent_only in /srv/www/themdc.org/current/web/app/themes/themdc/vendor/mwdelaney/sage-wp-nav-submenu/wp-nav-submenu.php on line 58`

Fixed needed on line 58 was 
`if (!empty($args->show_parent_only) && !$args->show_parent_only)`
